### PR TITLE
handle applications with multiple sources

### DIFF
--- a/argocd/argocd.go
+++ b/argocd/argocd.go
@@ -60,10 +60,12 @@ appLoop:
 			// the application source path.
 			// We add the trailing slash to prevent too ensure we match files inside the srcPath *directory*, not having
 			// srcPath as a prefix: e.g. path "dir/foo2.yaml" being associated with a different app that has a source path of "dir/foo"
-			if file == app.OwnPath || strings.HasPrefix(file, strings.TrimSuffix(app.SrcPath, "/")+"/") {
-				log.Printf("file %q belongs to %q", file, app.Name)
-				changed[app.Name] = struct{}{}
-				continue appLoop
+			for _, srcPath := range app.SrcPaths {
+				if file == app.OwnPath || strings.HasPrefix(file, strings.TrimSuffix(srcPath, "/")+"/") {
+					log.Printf("file %q belongs to %q", file, app.Name)
+					changed[app.Name] = struct{}{}
+					continue appLoop
+				}
 			}
 		}
 	}
@@ -81,9 +83,9 @@ appLoop:
 }
 
 type App struct {
-	Name    string
-	SrcPath string
-	OwnPath string
+	Name     string
+	SrcPaths []string
+	OwnPath  string
 }
 
 func Applications(root string) ([]App, error) {
@@ -129,10 +131,15 @@ func Applications(root string) ([]App, error) {
 			return nil
 		}
 
+		var paths []string
+		if app.Spec.Source.Path != "" {
+			paths = append(paths, app.Spec.Source.Path)
+		}
+
 		apps = append(apps, App{
-			Name:    app.Metadata.Name,
-			SrcPath: app.Spec.Source.Path,
-			OwnPath: path,
+			Name:     app.Metadata.Name,
+			SrcPaths: paths,
+			OwnPath:  path,
 		})
 
 		return nil

--- a/argocd/argocd.go
+++ b/argocd/argocd.go
@@ -99,6 +99,9 @@ func Applications(root string) ([]App, error) {
 			return nil
 		}
 
+		type sourceSpec struct {
+			Path string
+		}
 		var app struct {
 			APIVersion string `yaml:"apiVersion"`
 			Kind       string
@@ -106,9 +109,8 @@ func Applications(root string) ([]App, error) {
 				Name string
 			}
 			Spec struct {
-				Source struct {
-					Path string
-				}
+				Source  sourceSpec
+				Sources []sourceSpec
 			}
 		}
 
@@ -132,8 +134,10 @@ func Applications(root string) ([]App, error) {
 		}
 
 		var paths []string
-		if app.Spec.Source.Path != "" {
-			paths = append(paths, app.Spec.Source.Path)
+		for _, src := range append(app.Spec.Sources, app.Spec.Source) {
+			if src.Path != "" {
+				paths = append(paths, src.Path)
+			}
 		}
 
 		apps = append(apps, App{

--- a/argocd/argocd.go
+++ b/argocd/argocd.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"gopkg.in/yaml.v3"
@@ -60,12 +61,14 @@ appLoop:
 			// the application source path.
 			// We add the trailing slash to prevent too ensure we match files inside the srcPath *directory*, not having
 			// srcPath as a prefix: e.g. path "dir/foo2.yaml" being associated with a different app that has a source path of "dir/foo"
-			for _, srcPath := range app.SrcPaths {
-				if file == app.OwnPath || strings.HasPrefix(file, strings.TrimSuffix(srcPath, "/")+"/") {
-					log.Printf("file %q belongs to %q", file, app.Name)
-					changed[app.Name] = struct{}{}
-					continue appLoop
-				}
+			sourceIncludesFile := func(appSource string) bool {
+				return strings.HasPrefix(file, strings.TrimSuffix(appSource, "/")+"/")
+			}
+
+			if file == app.OwnPath || slices.ContainsFunc(app.SrcPaths, sourceIncludesFile) {
+				log.Printf("file %q belongs to %q", file, app.Name)
+				changed[app.Name] = struct{}{}
+				continue appLoop
 			}
 		}
 	}

--- a/argocd/argocd_test.go
+++ b/argocd/argocd_test.go
@@ -26,7 +26,7 @@ func Test_Applications(t *testing.T) {
 		},
 		{
 			appName:         "multisource",
-			expectedSources: []string{},
+			expectedSources: nil,
 		},
 	} {
 		appI := slices.IndexFunc(apps, func(app argocd.App) bool { return app.Name == tc.appName })
@@ -36,13 +36,13 @@ func Test_Applications(t *testing.T) {
 
 		app := apps[appI]
 
-		if app.SrcPath == "" && len(tc.expectedSources) != 0 {
+		if len(app.SrcPaths) != len(tc.expectedSources) {
 			t.Fatalf("%q does not have the expected sources", tc.appName)
 		}
 
 		for _, expectedSource := range tc.expectedSources {
-			if app.SrcPath != expectedSource {
-				t.Fatalf("expected source %q not found in app", expectedSource)
+			if !slices.Contains(app.SrcPaths, expectedSource) {
+				t.Fatalf("expected source %q not found in sources %v", expectedSource, app.SrcPaths)
 			}
 		}
 	}
@@ -53,14 +53,14 @@ func Test_Changed(t *testing.T) {
 
 	apps := []argocd.App{
 		{
-			Name:    "test app",
-			OwnPath: "dir/testapp.yaml",
-			SrcPath: "dir/testapp",
+			Name:     "test app",
+			OwnPath:  "dir/testapp.yaml",
+			SrcPaths: []string{"dir/testapp"},
 		},
 		{
-			Name:    "test app 2",
-			OwnPath: "dir/testapp2.yaml",
-			SrcPath: "dir/testapp2",
+			Name:     "test app 2",
+			OwnPath:  "dir/testapp2.yaml",
+			SrcPaths: []string{"dir/testapp2"},
 		},
 	}
 	expectedApp := []string{"test app"}
@@ -105,14 +105,14 @@ func Test_Changed(t *testing.T) {
 			name: "does not confuse apps with common prefixes",
 			apps: []argocd.App{
 				{
-					Name:    "foo",
-					SrcPath: "foo",
-					OwnPath: "foo.yaml",
+					Name:     "foo",
+					SrcPaths: []string{"foo"},
+					OwnPath:  "foo.yaml",
 				},
 				{
-					Name:    "foo2",
-					SrcPath: "foo2",
-					OwnPath: "foo2.yaml",
+					Name:     "foo2",
+					SrcPaths: []string{"foo2"},
+					OwnPath:  "foo2.yaml",
 				},
 			},
 			files:    []string{"foo2.yaml"},

--- a/argocd/argocd_test.go
+++ b/argocd/argocd_test.go
@@ -25,8 +25,11 @@ func Test_Applications(t *testing.T) {
 			},
 		},
 		{
-			appName:         "multisource",
-			expectedSources: nil,
+			appName: "multisource",
+			expectedSources: []string{
+				"auth/manifests",
+				"auth/somethingelse",
+			},
 		},
 	} {
 		appI := slices.IndexFunc(apps, func(app argocd.App) bool { return app.Name == tc.appName })
@@ -37,7 +40,7 @@ func Test_Applications(t *testing.T) {
 		app := apps[appI]
 
 		if len(app.SrcPaths) != len(tc.expectedSources) {
-			t.Fatalf("%q does not have the expected sources", tc.appName)
+			t.Fatalf("%q does not have the expected sources %v", tc.appName, tc.expectedSources)
 		}
 
 		for _, expectedSource := range tc.expectedSources {
@@ -55,7 +58,7 @@ func Test_Changed(t *testing.T) {
 		{
 			Name:     "test app",
 			OwnPath:  "dir/testapp.yaml",
-			SrcPaths: []string{"dir/testapp"},
+			SrcPaths: []string{"dir/testapp", "dir/testapp-extra"},
 		},
 		{
 			Name:     "test app 2",
@@ -87,6 +90,12 @@ func Test_Changed(t *testing.T) {
 			name:     "file inside source dir changed",
 			apps:     apps,
 			files:    []string{"another/file", "dir/testapp/something"},
+			expected: expectedApp,
+		},
+		{
+			name:     "file inside another source dir changed",
+			apps:     apps,
+			files:    []string{"another/file", "dir/testapp-extra/something"},
 			expected: expectedApp,
 		},
 		{

--- a/argocd/testdata/applications/multisource.yaml
+++ b/argocd/testdata/applications/multisource.yaml
@@ -1,0 +1,24 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: multisource
+  namespace: argocd
+spec:
+  destination:
+    namespace: auth
+    name: in-cluster
+  project: default
+  syncPolicy:
+    automated:
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+  sources:
+    - repoURL: example.internal/k8s-secrets
+      path: auth/manifests
+    - repoURL: example.internal/k8s-secrets
+      ref: secrets
+    - repoURL: example.internal/k8s
+      ref: values
+    - repoURL: example.internal/k8s-secrets
+      path: auth/somethingelse

--- a/argocd/testdata/applications/singlesource.yaml
+++ b/argocd/testdata/applications/singlesource.yaml
@@ -1,0 +1,23 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: singlesource
+  namespace: c-argocd
+spec:
+  destination:
+    namespace: singlesource
+    server: https://kubernetes.default.svc
+  project: nadia
+  source:
+    path: nadia/workloads/singlesource
+    repoURL: example.internal/k8s-secrets
+    targetRevision: main
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+    managedNamespaceMetadata:
+      labels:
+        owner: nadia


### PR DESCRIPTION
Implement handling for `Application` manifests which have `spec.sources` (plural) instead of, or in addition to, `spec.source`.